### PR TITLE
Implemented a couple of quick fixes for the macos version.

### DIFF
--- a/lena/lena_darwin.odin
+++ b/lena/lena_darwin.odin
@@ -207,7 +207,7 @@ os_step :: proc() {
 
 			// NOTE: It seems that MacOS registers holding down a key as multiple 
 			// "KeyDown" events. This check aims to ensure that we are properly
-			// assigning a "PRESSED" state if, and only i, we aren't already holding
+			// assigning a "PRESSED" state if, and only if, we aren't already holding
 			// down the key.
 			if ctx.key_state[code] & KEY_STATE_HELD != KEY_STATE_HELD {
 				ctx.key_state[code] = KEY_STATE_HELD | KEY_STATE_PRESSED


### PR DESCRIPTION
This commit aims to fix a couple of bugs I encountered while experimenting with the library.

The first fix I implemented is related to the "key_pressed" procedure. It seemed that the behavior on MacOS was different to how it's described in the documentation found in the "lena" folder. Before my fix, when holding down any key, it would continue to report that it was just being pressed that frame every so often. That has now been fixed and matches the behavior described in the documentation.

The other issue I encountered was a growing amount of memory being used by the process. I noticed this when moving my mouse across the window and seeing in the activity monitor the memory used increase. I've narrowed it down to the "os_step  procedure, which now has a autoreleasepool to clean the obj-c objects allocated in the procedure every frame.